### PR TITLE
Replace almost all arrow functions with function declarations

### DIFF
--- a/api/controllers/authentication.js
+++ b/api/controllers/authentication.js
@@ -1,7 +1,7 @@
 const User = require("../models/user");
 const { generateToken } = require("../lib/token");
 
-const createToken = async (req, res) => {
+async function createToken(req, res) {
   const email = req.body.email;
   const password = req.body.password;
 
@@ -16,7 +16,7 @@ const createToken = async (req, res) => {
     const token = generateToken(user.id);
     res.status(201).json({ token: token, message: "OK" });
   }
-};
+}
 
 const AuthenticationController = {
   createToken: createToken,

--- a/api/controllers/posts.js
+++ b/api/controllers/posts.js
@@ -1,19 +1,19 @@
 const Post = require("../models/post");
 const { generateToken } = require("../lib/token");
 
-const getAllPosts = async (req, res) => {
+async function getAllPosts(req, res) {
   const posts = await Post.find();
   const token = generateToken(req.user_id);
   res.status(200).json({ posts: posts, token: token });
-};
+}
 
-const createPost = async (req, res) => {
+async function createPost(req, res) {
   const post = new Post(req.body);
   post.save();
 
   const newToken = generateToken(req.user_id);
   res.status(201).json({ message: "Post created", token: newToken });
-};
+}
 
 const PostsController = {
   getAllPosts: getAllPosts,

--- a/api/controllers/users.js
+++ b/api/controllers/users.js
@@ -1,6 +1,6 @@
 const User = require("../models/user");
 
-const create = (req, res) => {
+function create(req, res) {
   const email = req.body.email;
   const password = req.body.password;
 
@@ -15,7 +15,7 @@ const create = (req, res) => {
       console.error(err);
       res.status(400).json({ message: "Something went wrong" });
     });
-};
+}
 
 const UsersController = {
   create: create,

--- a/api/db/db.js
+++ b/api/db/db.js
@@ -1,6 +1,6 @@
 const mongoose = require("mongoose");
 
-const connectToDatabase = async () => {
+async function connectToDatabase() {
   const mongoDbUrl = process.env.MONGODB_URL;
 
   if (!mongoDbUrl) {
@@ -15,6 +15,6 @@ const connectToDatabase = async () => {
   if (process.env.NODE_ENV !== "test") {
     console.log("Successfully connected to MongoDB");
   }
-};
+}
 
 module.exports = { connectToDatabase };

--- a/api/index.js
+++ b/api/index.js
@@ -4,12 +4,12 @@ require("dotenv").config();
 const app = require("./app.js");
 const { connectToDatabase } = require("./db/db.js");
 
-const listenForRequests = () => {
+function listenForRequests() {
   const port = process.env.PORT || 3000;
   app.listen(port, () => {
     console.log("Now listening on port", port);
   });
-};
+}
 
 connectToDatabase().then(() => {
   listenForRequests();

--- a/api/lib/token.js
+++ b/api/lib/token.js
@@ -6,7 +6,7 @@ const secret = process.env.JWT_SECRET;
  * token for a specific user.
  * JWTs in 100 Seconds: https://www.youtube.com/watch?v=UBUNrFtufWo
  */
-const generateToken = (user_id) => {
+function generateToken(user_id) {
   return JWT.sign(
     {
       user_id: user_id,
@@ -17,10 +17,10 @@ const generateToken = (user_id) => {
     },
     secret
   );
-};
+}
 
-const decodeToken = (token) => {
+function decodeToken(token) {
   return JWT.decode(token, secret);
-};
+}
 
 module.exports = { generateToken, decodeToken };

--- a/api/middleware/tokenChecker.js
+++ b/api/middleware/tokenChecker.js
@@ -1,7 +1,7 @@
 const JWT = require("jsonwebtoken");
 
 // Middleware function to check for valid tokens
-const tokenChecker = (req, res, next) => {
+function tokenChecker(req, res, next) {
   let token;
   const authHeader = req.get("Authorization");
 
@@ -19,6 +19,6 @@ const tokenChecker = (req, res, next) => {
       next();
     }
   });
-};
+}
 
 module.exports = tokenChecker;

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1418,12 +1418,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1712,9 +1712,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2000,16 +2000,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -2040,43 +2040,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2099,9 +2062,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2433,10 +2396,22 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -3210,6 +3185,11 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -4161,15 +4141,15 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },

--- a/api/tests/controllers/posts.test.js
+++ b/api/tests/controllers/posts.test.js
@@ -9,7 +9,7 @@ require("../mongodb_helper");
 
 const secret = process.env.JWT_SECRET;
 
-const createToken = (userId) => {
+function createToken(userId) {
   return JWT.sign(
     {
       user_id: userId,
@@ -20,7 +20,7 @@ const createToken = (userId) => {
     },
     secret
   );
-};
+}
 
 let token;
 describe("/posts", () => {

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -96,11 +96,11 @@ import MyClass from "./path/to/other/file.js";
 To export multiple values, we can use the `export` keyword more than once:
 
 ```js
-export const add = (a, b) => {
+export function add (a, b){
   return a + b;
 };
 
-export const multiply = (a, b) => {
+export function multiply (a, b){
   return a * b;
 };
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1648,12 +1648,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2440,9 +2440,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4656,9 +4656,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
-      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -4968,9 +4968,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,12 +26,12 @@ const router = createBrowserRouter([
   },
 ]);
 
-const App = () => {
+function App() {
   return (
     <>
       <RouterProvider router={router} />
     </>
   );
-};
+}
 
 export default App;

--- a/frontend/src/components/LogoutButton.jsx
+++ b/frontend/src/components/LogoutButton.jsx
@@ -1,7 +1,6 @@
-import React from "react";
 import { useNavigate } from "react-router-dom";
 
-function LogoutButton(props) {
+function LogoutButton() {
   const navigate = useNavigate();
 
   function logOut() {

--- a/frontend/src/components/LogoutButton.jsx
+++ b/frontend/src/components/LogoutButton.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+function LogoutButton(props) {
+  const navigate = useNavigate();
+
+  function logOut() {
+    localStorage.removeItem("token");
+    navigate("/");
+  }
+
+  return <button onClick={logOut}>Log out</button>;
+}
+
+export default LogoutButton;

--- a/frontend/src/components/Post.jsx
+++ b/frontend/src/components/Post.jsx
@@ -1,5 +1,5 @@
-const Post = (props) => {
+function Post(props) {
   return <article key={props.post._id}>{props.post.message}</article>;
-};
+}
 
 export default Post;

--- a/frontend/src/pages/Feed/FeedPage.jsx
+++ b/frontend/src/pages/Feed/FeedPage.jsx
@@ -2,15 +2,17 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { getPosts } from "../../services/posts";
-import Post from "../../components/Post/Post";
+import Post from "../../components/Post";
+import LogoutButton from "../../components/LogoutButton";
 
-export const FeedPage = () => {
+export function FeedPage() {
   const [posts, setPosts] = useState([]);
   const navigate = useNavigate();
 
   useEffect(() => {
     const token = localStorage.getItem("token");
-    if (token) {
+    const loggedIn = token !== null;
+    if (loggedIn) {
       getPosts(token)
         .then((data) => {
           setPosts(data.posts);
@@ -37,6 +39,7 @@ export const FeedPage = () => {
           <Post post={post} key={post._id} />
         ))}
       </div>
+      <LogoutButton />
     </>
   );
-};
+}

--- a/frontend/src/pages/Home/HomePage.jsx
+++ b/frontend/src/pages/Home/HomePage.jsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 
 import "./HomePage.css";
 
-export const HomePage = () => {
+export function HomePage() {
   return (
     <div className="home">
       <h1>Welcome to Acebook!</h1>
@@ -10,4 +10,4 @@ export const HomePage = () => {
       <Link to="/login">Log In</Link>
     </div>
   );
-};
+}

--- a/frontend/src/pages/Login/LoginPage.jsx
+++ b/frontend/src/pages/Login/LoginPage.jsx
@@ -3,12 +3,12 @@ import { useNavigate } from "react-router-dom";
 
 import { login } from "../../services/authentication";
 
-export const LoginPage = () => {
+export function LoginPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const navigate = useNavigate();
 
-  const handleSubmit = async (event) => {
+  async function handleSubmit(event) {
     event.preventDefault();
     try {
       const token = await login(email, password);
@@ -18,15 +18,15 @@ export const LoginPage = () => {
       console.error(err);
       navigate("/login");
     }
-  };
+  }
 
-  const handleEmailChange = (event) => {
+  function handleEmailChange(event) {
     setEmail(event.target.value);
-  };
+  }
 
-  const handlePasswordChange = (event) => {
+  function handlePasswordChange(event) {
     setPassword(event.target.value);
-  };
+  }
 
   return (
     <>
@@ -50,4 +50,4 @@ export const LoginPage = () => {
       </form>
     </>
   );
-};
+}

--- a/frontend/src/pages/Signup/SignupPage.jsx
+++ b/frontend/src/pages/Signup/SignupPage.jsx
@@ -3,30 +3,29 @@ import { useNavigate } from "react-router-dom";
 
 import { signup } from "../../services/authentication";
 
-export const SignupPage = () => {
+export function SignupPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const navigate = useNavigate();
 
-  const handleSubmit = async (event) => {
+  async function handleSubmit(event) {
     event.preventDefault();
     try {
       await signup(email, password);
-      console.log("redirecting...:");
       navigate("/login");
     } catch (err) {
       console.error(err);
       navigate("/signup");
     }
-  };
+  }
 
-  const handleEmailChange = (event) => {
+  function handleEmailChange(event) {
     setEmail(event.target.value);
-  };
+  }
 
-  const handlePasswordChange = (event) => {
+  function handlePasswordChange(event) {
     setPassword(event.target.value);
-  };
+  }
 
   return (
     <>
@@ -51,4 +50,4 @@ export const SignupPage = () => {
       </form>
     </>
   );
-};
+}

--- a/frontend/src/services/authentication.js
+++ b/frontend/src/services/authentication.js
@@ -1,7 +1,7 @@
 // docs: https://vitejs.dev/guide/env-and-mode.html
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
 
-export const login = async (email, password) => {
+export async function login(email, password) {
   const payload = {
     email: email,
     password: password,
@@ -26,9 +26,9 @@ export const login = async (email, password) => {
       `Received status ${response.status} when logging in. Expected 201`
     );
   }
-};
+}
 
-export const signup = async (email, password) => {
+export async function signup(email, password) {
   const payload = {
     email: email,
     password: password,
@@ -52,4 +52,4 @@ export const signup = async (email, password) => {
       `Received status ${response.status} when signing up. Expected 201`
     );
   }
-};
+}

--- a/frontend/src/services/posts.js
+++ b/frontend/src/services/posts.js
@@ -1,7 +1,7 @@
 // docs: https://vitejs.dev/guide/env-and-mode.html
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
 
-export const getPosts = async (token) => {
+export async function getPosts(token) {
   const requestOptions = {
     method: "GET",
     headers: {
@@ -17,4 +17,4 @@ export const getPosts = async (token) => {
 
   const data = await response.json();
   return data;
-};
+}

--- a/frontend/tests/components/post.test.jsx
+++ b/frontend/tests/components/post.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 
-import Post from "../../src/components/Post/Post";
+import Post from "../../src/components/Post";
 
 describe("Post", () => {
   test("displays the message as an article", () => {

--- a/frontend/tests/pages/loginPage.test.jsx
+++ b/frontend/tests/pages/loginPage.test.jsx
@@ -21,7 +21,7 @@ vi.mock("../../src/services/authentication", () => {
 });
 
 // Reusable function for filling out login form
-const completeLoginForm = async () => {
+async function completeLoginForm() {
   const user = userEvent.setup();
 
   const emailInputEl = screen.getByLabelText("Email:");
@@ -31,7 +31,7 @@ const completeLoginForm = async () => {
   await user.type(emailInputEl, "test@email.com");
   await user.type(passwordInputEl, "1234");
   await user.click(submitButtonEl);
-};
+}
 
 describe("Login Page", () => {
   beforeEach(() => {

--- a/frontend/tests/pages/signupPage.test.jsx
+++ b/frontend/tests/pages/signupPage.test.jsx
@@ -21,7 +21,7 @@ vi.mock("../../src/services/authentication", () => {
 });
 
 // Reusable function for filling out signup form
-const completeSignupForm = async () => {
+async function completeSignupForm() {
   const user = userEvent.setup();
 
   const emailInputEl = screen.getByLabelText("Email:");
@@ -31,7 +31,7 @@ const completeSignupForm = async () => {
   await user.type(emailInputEl, "test@email.com");
   await user.type(passwordInputEl, "1234");
   await user.click(submitButtonEl);
-};
+}
 
 describe("Signup Page", () => {
   beforeEach(() => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "Note": "This is a dummy package.json file to prevent accidental installation or running of packages in the wrong file",
+  "Note": "This is a dummy package.json file to prevent accidental installation or running of packages in the wrong location",
   "scripts": {
     "dev": "echo 'You are in the wrong directory. cd to api or frontend folder to run this command'",
     "start": "echo 'You are in the wrong directory. cd to api or frontend folder to run this command'",


### PR DESCRIPTION
This PR replaces (almost) all arrow functions in the Acebook repo with classic function declarations.

I have noticed that a lot of learners at this point in the course are struggling to identify arrow functions as functions.

The original purpose of this decision was to reinforce the idea of functions being values like any other within JavaScript, but for learners who are still getting to grips with the syntax of JS,

```js
const someFunction = (arg1, arg2) => {

};
```

looks too similar to 

```js
const someObject = {

};
```

and this is causing confusion.

Additionally, there has been challenge within the professional JS community of the idea that arrow functions should be used wherever possible. They have simpler `this` rules, but there is a performance reduction, and we don't use `this` in this codebase anyway.