### PR TITLE
Remove React Router

### DIFF
--- a/docs/frontend_structure.md
+++ b/docs/frontend_structure.md
@@ -25,12 +25,9 @@ to insert our App into that div.
 ### App.jsx
 
 This file contains our application. It imports all of the pages we want in our
-application, and uses React Router to serve them at specific URLs. Unlike
-previous web applications you may have worked on, these different URLs don't
-represent different backend routes. They are handled purely by the frontend. Any
-request to any of these routes will be served the same HTML and JS files for the
-React application, and the application will then determine how to handle the
-route.
+application, and displays them based on the `currentPage` state. It uses
+[conditional rendering](https://react.dev/learn/conditional-rendering#logical-and-operator-)
+to only render one page.
 
 ### Pages
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-router-dom": "^6.14.2"
+        "react-dom": "^18.2.0"
       },
       "devDependencies": {
         "@testing-library/react": "^14.0.0",
@@ -720,14 +719,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.7.2.tgz",
-      "integrity": "sha512-7Lcn7IqGMV+vizMPoEl5F0XDshcdDYtMI6uJLQdQz5CfZAwy3vvGKYSUk789qndt5dEC4HfSjviSYlSoHGL2+A==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1648,12 +1639,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2440,9 +2431,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3405,12 +3396,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -3977,36 +3968,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "node_modules/react-router": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.14.2.tgz",
-      "integrity": "sha512-09Zss2dE2z+T1D03IheqAFtK4UzQyX8nFPWx6jkwdYzGLXd5ie06A6ezS2fO6zJfEb/SpG6UocN2O1hfD+2urQ==",
-      "dependencies": {
-        "@remix-run/router": "1.7.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.14.2.tgz",
-      "integrity": "sha512-5pWX0jdKR48XFZBuJqHosX3AAHjRAzygouMTyimnBPOLdY3WjzUSKhus2FVMihUFWzeLebDgr4r8UeQFAct7Bg==",
-      "dependencies": {
-        "@remix-run/router": "1.7.2",
-        "react-router": "6.14.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
     },
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
@@ -4656,9 +4617,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
-      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -4968,9 +4929,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,8 +12,7 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.14.2"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,35 +1,23 @@
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { useState } from "react";
 
-import "./App.css";
 import { HomePage } from "./pages/Home/HomePage";
 import { LoginPage } from "./pages/Login/LoginPage";
 import { SignupPage } from "./pages/Signup/SignupPage";
 import { FeedPage } from "./pages/Feed/FeedPage";
 
-// docs: https://reactrouter.com/en/main/start/overview
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <HomePage />,
-  },
-  {
-    path: "/login",
-    element: <LoginPage />,
-  },
-  {
-    path: "/signup",
-    element: <SignupPage />,
-  },
-  {
-    path: "/posts",
-    element: <FeedPage />,
-  },
-]);
+import "./App.css";
 
 const App = () => {
+  const [currentPage, setPage] = useState("home");
+
+  // This uses conditional rendering, using the && operator.
+  // Read more here: https://react.dev/learn/conditional-rendering#logical-and-operator-
   return (
     <>
-      <RouterProvider router={router} />
+      {currentPage === "home" && <HomePage setPage={setPage} />}
+      {currentPage === "login" && <LoginPage setPage={setPage} />}
+      {currentPage === "signup" && <SignupPage setPage={setPage} />}
+      {currentPage === "feed" && <FeedPage setPage={setPage} />}
     </>
   );
 };

--- a/frontend/src/pages/Feed/FeedPage.jsx
+++ b/frontend/src/pages/Feed/FeedPage.jsx
@@ -1,12 +1,11 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 
 import { getPosts } from "../../services/posts";
 import Post from "../../components/Post/Post";
 
-export const FeedPage = () => {
+export const FeedPage = ({ props }) => {
   const [posts, setPosts] = useState([]);
-  const navigate = useNavigate();
+  const changePage = props.setPage;
 
   useEffect(() => {
     const token = localStorage.getItem("token");
@@ -18,14 +17,14 @@ export const FeedPage = () => {
         })
         .catch((err) => {
           console.error(err);
-          navigate("/login");
+          changePage("login");
         });
     }
-  }, [navigate]);
+  }, [changePage]);
 
   const token = localStorage.getItem("token");
   if (!token) {
-    navigate("/login");
+    changePage("login");
     return;
   }
 

--- a/frontend/src/pages/Home/HomePage.jsx
+++ b/frontend/src/pages/Home/HomePage.jsx
@@ -1,13 +1,21 @@
-import { Link } from "react-router-dom";
-
 import "./HomePage.css";
 
-export const HomePage = () => {
+export const HomePage = (props) => {
+  const DOCS_URL =
+    "https://github.com/makersacademy/acebook-mern-vite/blob/main/DOCUMENTATION.md";
+
   return (
     <div className="home">
       <h1>Welcome to Acebook!</h1>
-      <Link to="/signup">Sign Up</Link>
-      <Link to="/login">Log In</Link>
+      <a href="#" onClick={() => props.setPage("signup")}>
+        Sign Up
+      </a>
+      <a href="#" onClick={() => props.setPage("login")}>
+        Log In
+      </a>
+      <p>
+        Documentation for this project can be found <a href={DOCS_URL}>here.</a>
+      </p>
     </div>
   );
 };

--- a/frontend/src/pages/Login/LoginPage.jsx
+++ b/frontend/src/pages/Login/LoginPage.jsx
@@ -1,22 +1,20 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 import { login } from "../../services/authentication";
 
-export const LoginPage = () => {
+export const LoginPage = (props) => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const navigate = useNavigate();
 
   const handleSubmit = async (event) => {
     event.preventDefault();
     try {
       const token = await login(email, password);
       localStorage.setItem("token", token);
-      navigate("/posts");
+      props.setPage("feed");
     } catch (err) {
       console.error(err);
-      navigate("/login");
+      props.setPage("login");
     }
   };
 

--- a/frontend/src/pages/Signup/SignupPage.jsx
+++ b/frontend/src/pages/Signup/SignupPage.jsx
@@ -1,22 +1,20 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 import { signup } from "../../services/authentication";
 
-export const SignupPage = () => {
+export const SignupPage = (props) => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const navigate = useNavigate();
 
   const handleSubmit = async (event) => {
     event.preventDefault();
     try {
       await signup(email, password);
       console.log("redirecting...:");
-      navigate("/login");
+      props.setPage("login");
     } catch (err) {
       console.error(err);
-      navigate("/signup");
+      props.setPage("signup");
     }
   };
 

--- a/frontend/tests/pages/feedPage.test.jsx
+++ b/frontend/tests/pages/feedPage.test.jsx
@@ -3,19 +3,11 @@ import { vi } from "vitest";
 
 import { FeedPage } from "../../src/pages/Feed/FeedPage";
 import { getPosts } from "../../src/services/posts";
-import { useNavigate } from "react-router-dom";
 
 // Mocking the getPosts service
 vi.mock("../../src/services/posts", () => {
   const getPostsMock = vi.fn();
   return { getPosts: getPostsMock };
-});
-
-// Mocking React Router's useNavigate function
-vi.mock("react-router-dom", () => {
-  const navigateMock = vi.fn();
-  const useNavigateMock = () => navigateMock; // Create a mock function for useNavigate
-  return { useNavigate: useNavigateMock };
 });
 
 describe("Feed Page", () => {
@@ -30,15 +22,15 @@ describe("Feed Page", () => {
 
     getPosts.mockResolvedValue({ posts: mockPosts, token: "newToken" });
 
-    render(<FeedPage />);
+    render(<FeedPage setPage={() => {}} />);
 
     const post = await screen.findByRole("article");
     expect(post.textContent).toEqual("Test Post 1");
   });
 
   test("It navigates to login if no token is present", async () => {
-    render(<FeedPage />);
-    const navigateMock = useNavigate();
-    expect(navigateMock).toHaveBeenCalledWith("/login");
+    const setPageMock = vi.fn();
+    render(<FeedPage setPage={setPageMock} />);
+    expect(setPageMock).toHaveBeenCalledWith("login");
   });
 });

--- a/frontend/tests/pages/homePage.test.jsx
+++ b/frontend/tests/pages/homePage.test.jsx
@@ -1,40 +1,36 @@
 import { render, screen } from "@testing-library/react";
-import { BrowserRouter } from "react-router-dom";
+import { vi } from "vitest";
 
 import { HomePage } from "../../src/pages/Home/HomePage";
+import userEvent from "@testing-library/user-event";
 
 describe("Home Page", () => {
   test("welcomes you to the site", () => {
-    // We need the Browser Router so that the Link elements load correctly
-    render(
-      <BrowserRouter>
-        <HomePage />
-      </BrowserRouter>
-    );
+    render(<HomePage setPage={() => {}} />);
 
     const heading = screen.getByRole("heading");
     expect(heading.textContent).toEqual("Welcome to Acebook!");
   });
 
   test("Displays a signup link", async () => {
-    render(
-      <BrowserRouter>
-        <HomePage />
-      </BrowserRouter>
-    );
+    const user = userEvent.setup();
+
+    const setPageMock = vi.fn();
+    render(<HomePage setPage={setPageMock} />);
 
     const signupLink = screen.getByText("Sign Up");
-    expect(signupLink.getAttribute("href")).toEqual("/signup");
+    await user.click(signupLink);
+    expect(setPageMock).toHaveBeenCalledWith("signup");
   });
 
   test("Displays a login link", async () => {
-    render(
-      <BrowserRouter>
-        <HomePage />
-      </BrowserRouter>
-    );
+    const user = userEvent.setup();
+
+    const setPageMock = vi.fn();
+    render(<HomePage setPage={setPageMock} />);
 
     const loginLink = screen.getByText("Log In");
-    expect(loginLink.getAttribute("href")).toEqual("/login");
+    await user.click(loginLink);
+    expect(setPageMock).toHaveBeenCalledWith("signup");
   });
 });

--- a/frontend/tests/pages/loginPage.test.jsx
+++ b/frontend/tests/pages/loginPage.test.jsx
@@ -2,17 +2,8 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
-import { useNavigate } from "react-router-dom";
 import { login } from "../../src/services/authentication";
-
 import { LoginPage } from "../../src/pages/Login/LoginPage";
-
-// Mocking React Router's useNavigate function
-vi.mock("react-router-dom", () => {
-  const navigateMock = vi.fn();
-  const useNavigateMock = () => navigateMock; // Create a mock function for useNavigate
-  return { useNavigate: useNavigateMock };
-});
 
 // Mocking the login service
 vi.mock("../../src/services/authentication", () => {
@@ -39,7 +30,7 @@ describe("Login Page", () => {
   });
 
   test("allows a user to login", async () => {
-    render(<LoginPage />);
+    render(<LoginPage setPage={() => {}} />);
 
     await completeLoginForm();
 
@@ -47,24 +38,24 @@ describe("Login Page", () => {
   });
 
   test("navigates to /posts on successful login", async () => {
-    render(<LoginPage />);
+    const setPageMock = vi.fn();
+    render(<LoginPage setPage={setPageMock} />);
 
     login.mockResolvedValue("secrettoken123");
-    const navigateMock = useNavigate();
 
     await completeLoginForm();
 
-    expect(navigateMock).toHaveBeenCalledWith("/posts");
+    expect(setPageMock).toHaveBeenCalledWith("posts");
   });
 
   test("navigates to /login on unsuccessful login", async () => {
-    render(<LoginPage />);
+    const setPageMock = vi.fn();
+    render(<LoginPage setPage={setPageMock} />);
 
     login.mockRejectedValue(new Error("Error logging in"));
-    const navigateMock = useNavigate();
 
     await completeLoginForm();
 
-    expect(navigateMock).toHaveBeenCalledWith("/login");
+    expect(setPageMock).toHaveBeenCalledWith("login");
   });
 });

--- a/frontend/tests/pages/signupPage.test.jsx
+++ b/frontend/tests/pages/signupPage.test.jsx
@@ -2,17 +2,9 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 
-import { useNavigate } from "react-router-dom";
 import { signup } from "../../src/services/authentication";
 
 import { SignupPage } from "../../src/pages/Signup/SignupPage";
-
-// Mocking React Router's useNavigate function
-vi.mock("react-router-dom", () => {
-  const navigateMock = vi.fn();
-  const useNavigateMock = () => navigateMock; // Create a mock function for useNavigate
-  return { useNavigate: useNavigateMock };
-});
 
 // Mocking the signup service
 vi.mock("../../src/services/authentication", () => {
@@ -39,7 +31,7 @@ describe("Signup Page", () => {
   });
 
   test("allows a user to signup", async () => {
-    render(<SignupPage />);
+    render(<SignupPage setPage={() => {}} />);
 
     await completeSignupForm();
 
@@ -47,23 +39,22 @@ describe("Signup Page", () => {
   });
 
   test("navigates to /login on successful signup", async () => {
-    render(<SignupPage />);
-
-    const navigateMock = useNavigate();
+    const setPageMock = vi.fn();
+    render(<SignupPage setPage={setPageMock} />);
 
     await completeSignupForm();
 
-    expect(navigateMock).toHaveBeenCalledWith("/login");
+    expect(setPageMock).toHaveBeenCalledWith("login");
   });
 
   test("navigates to /signup on unsuccessful signup", async () => {
-    render(<SignupPage />);
+    const setPageMock = vi.fn();
+    render(<SignupPage setPage={setPageMock} />);
 
     signup.mockRejectedValue(new Error("Error signing up"));
-    const navigateMock = useNavigate();
 
     await completeSignupForm();
 
-    expect(navigateMock).toHaveBeenCalledWith("/signup");
+    expect(setPageMock).toHaveBeenCalledWith("signup");
   });
 });


### PR DESCRIPTION
React Router is industry standard, and very powerful, but in the past has been a big stumbling block to understanding what's going on in the template repo. This PR removes it, instead opting for a single state value that determines which page to render.

Hopefully this will help reinforce the idea of the frontend as a **Single Page Application**, distinguishing it from the types of applications learners have built previously. Adding (and understanding!) React Router could then be a ticket on the Acebook Trello.

I'm not 100% sure about this change, because it does make the application harder to use. Specifically, not being able to use the back button is a pain, but maybe this pain is actually a good thing, as they will understand the utility of React Router once they add it?

Definitely one for discussion, so please let me know your thoughts.